### PR TITLE
Add keyboard support

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,6 +108,12 @@
 								<input style="width: 80px;" type="text" name="inputPort" id="inputPort" class="form-control" placeholder="Port" required="" autofocus="" value="8191">
 							</div>
 						</div>
+
+                        <div class="row">
+							<div class="col" >
+							<textarea name="keyboardLayout" id="keyboardLayout" class="form-control mt-2" placeholder="Keyboard Layout" autoHeight="true" autofocus=False></textarea>
+							</div>
+						</div>
 						<button class="btn btn-primary mt-2 w-100" type="submit">
 							<span id="button-connect-spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
 							Connect


### PR DESCRIPTION
If a machine has a keyboard but doesn't have a touchscreen or mouse, then I could config the keyboard layout and use its keyboard to control the macro deck server.
Each machine could also have a different keyboard layout, the keyboard layout saved in the browser as a cookie.

Refer to #281 for more details, but this is not the case.
https://github.com/Macro-Deck-org/Macro-Deck/issues/281

keys split by `,` and `\n`. `\n` means keys in different lines. the value is event.key in javascript.
Special, you need to use `\,` or `Comma` instead of comma key.

![image](https://user-images.githubusercontent.com/3126801/205422104-b4dca079-f96b-4634-aa81-ce4c6086d8be.png)
